### PR TITLE
feat: disable PurgeCSS by passing 'off' to options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,17 @@ module.exports = (eleventyConfig) => {
 };
 ```
 
+You can disable the plugin by passing `'off'` as an option, like this:
+
+```js
+// .eleventy.js
+module.exports = (eleventyConfig) => {
+  eleventyConfig.addPlugin(styles, {
+    purgeCSSOptions: 'off',
+  });
+};
+```
+
 > Avoid overriding `content` property and `css`, because they are used internally and that may cause unexpected results.
 
 ### cssnanoOptions

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -2,7 +2,7 @@ import purgecss from '@fullhuman/postcss-purgecss';
 import autoprefixer from 'autoprefixer';
 import postcss, { AcceptedPlugin } from 'postcss';
 import cssnano, { CssNanoOptions } from 'cssnano';
-
+import { PurgeCSSOptions, PluginState } from './types';
 export interface NormalizeStepOptions {
   /** Path of source style file. */
   url: string;
@@ -11,7 +11,7 @@ export interface NormalizeStepOptions {
   /** HTML content that has link to _css_. */
   html: string;
   /** Options to be passed to [`PurgeCSS`](https://purgecss.com/). */
-  purgeCSSOptions?: Parameters<typeof purgecss>[0];
+  purgeCSSOptions?: PurgeCSSOptions;
   /** Options to be passed to [`CSSNano`](https://cssnano.co/). */
   cssnanoOptions?: CssNanoOptions;
   /** Array of plugins that can be passed to [`PostCSS`](https://postcss.org). */
@@ -33,13 +33,13 @@ export const normalize = async ({
   // Useful plugins for PostCSS configuration.
   const plugins: any[] = [
     ...postcssPlugins,
-    purgecss({
+    (purgeCSSOptions !== PluginState.Off) ? purgecss({
       content: [{ raw: html, extension: 'html' }],
       ...purgeCSSOptions,
-    }),
+    }) : null,
     autoprefixer,
     cssnano({ preset: 'default', ...cssnanoOptions }),
-  ];
+  ].filter(Boolean);
 
   return postcss(plugins).process(css, { from: fromUrl });
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import purgecss from '@fullhuman/postcss-purgecss';
 import { SassCompilerOptions } from './compile';
 import { NormalizeStepOptions } from './normalize';
 
@@ -34,6 +35,12 @@ interface CriticalOptions {
   readonly inlineImages?: boolean;
   readonly maxImageFileSize?: number;
 }
+
+export enum PluginState {
+  Off = "off",
+}
+
+export type PurgeCSSOptions = Parameters<typeof purgecss>[0] | PluginState.Off;
 
 export type StylesPluginOptions = {
   /**


### PR DESCRIPTION
Fixes https://github.com/Halo-Lab/eleventy-plugin-styles/issues/4

For now I added support for disabling PurgeCSS only as it's the only thing I had personal interest in having. Disabling other plugins can be implemented in a similar fashion but I'm not sure if anyone else needs that. :)